### PR TITLE
Send a new PWM value to MaBeee

### DIFF
--- a/iot_train.ino
+++ b/iot_train.ino
@@ -560,5 +560,8 @@ void onLedWritten(BLEDevice central, BLECharacteristic characteristic) {
 void onPwmWritten(BLEDevice central, BLECharacteristic characteristic) {
     Serial.println("Debug: onPwmWritten");
     pwmPacket pwm;
-    memcpy(pwm.byteArray, characteristic.value(), sizeof(pwm.byteArray));
+    bzero(pwm.byteArray, sizeof(pwm.byteArray));
+    pwm.byteArray[0] = 0x01;
+    pwm.byteArray[1] = characteristic.value()[0];
+    mabeeePwmCharacteristic.writeValue(pwm.byteArray, sizeof(pwm.byteArray));
 }


### PR DESCRIPTION
onPwmWritten() の中で、XIAOのpwmCharacteristicに書き込まれた値をmabeeePwmCharacteristicへ渡してみました。これで、XIAOを介してMaBeeeのPWMを制御できるようになったと思います。他には何も変えてないつもりですが値も読み出せるようです。（これで十分なのかどうかわかっていません。）
※ まだcompesysからは変えられません。⇒ compesysのコミットd5fbb5751675a6979244f22b711498bfbaa0f1a6で対応済み。