### PR TITLE
Add user descriptors to XIAO characteristics.

### DIFF
--- a/iot_train.h
+++ b/iot_train.h
@@ -69,30 +69,37 @@ typedef union {
 #define XIAO_COMMAND_CHAR_PROP (BLEWrite|BLENotify)                     // property:command characteristic, writable/notifiable
 #define XIAO_COMMAND_CHAR_TYPE BLECharacteristic                        // type:command characteristic, byte array
 #define XIAO_COMMAND_CHAR_LEN 21                                        // length:command characteristic, 21 bytes
+#define XIAO_COMMAND_CHAR_NAME "command"                                // user descriptor: "command"
 #define XIAO_ACCEL_CHAR_UUID "AD0C1002-64E9-48B0-9088-6F9E9FE4972E"     // UUID:accelerometer characteristic
 #define XIAO_ACCEL_CHAR_PROP (BLERead|BLENotify)                        // property:accelerometer characteristic, readable/notifiable
 #define XIAO_ACCEL_CHAR_TYPE BLECharacteristic                          // type:accelerometer characteristic, byte array
 #define XIAO_ACCEL_CHAR_LEN 16                                          // length:accelerometer characteristic, 16 bytes
+#define XIAO_ACCEL_CHAR_NAME "accelerometer"                            // user descriptor: "accelerometer"
 #define XIAO_GYRO_CHAR_UUID "AD0C1003-64E9-48B0-9088-6F9E9FE4972E"      // UUID:gyroscope characteristic
 #define XIAO_GYRO_CHAR_PROP (BLERead|BLENotify)                         // property:gyroscope characteristic, readable/notifiable
 #define XIAO_GYRO_CHAR_TYPE BLECharacteristic                           // type:gyroscope characteristic, byte array
 #define XIAO_GYRO_CHAR_LEN 16                                           // length:gyroscope characteristic, 16 bytes
+#define XIAO_GYRO_CHAR_NAME "gyroscope"                                 // user descriptor: "gyroscope"
 #define XIAO_TEMP_CHAR_UUID "AD0C1004-64E9-48B0-9088-6F9E9FE4972E"      // UUID:temperature characteristic
 #define XIAO_TEMP_CHAR_PROP (BLERead|BLENotify)                         // property:temperature characteristic, readable/notifiable
 #define XIAO_TEMP_CHAR_TYPE BLECharacteristic                           // type:temperature characteristic, byte array
 #define XIAO_TEMP_CHAR_LEN 8                                            // length:temperature characteristic, 8 bytes
+#define XIAO_TEMP_CHAR_NAME "temperature"                               // user descriptor: "temperature"
 #define XIAO_LED_CHAR_UUID "AD0C1005-64E9-48B0-9088-6F9E9FE4972E"       // UUID:LED characteristic
 #define XIAO_LED_CHAR_PROP (BLERead|BLEWrite)                           // property:LED characteristic, readable/writable
 #define XIAO_LED_CHAR_TYPE BLEUnsignedCharCharacteristic                // type:LED characteristic, unsigned char
 #define XIAO_LED_CHAR_LEN 1                                             // length:LED characteristic, 1 byte
+#define XIAO_LED_CHAR_NAME "led"                                        // user descriptor: "led"
 #define XIAO_PWM_CHAR_UUID "AD0C2001-64E9-48B0-9088-6F9E9FE4972E"       // UUID:PWM characteristic
 #define XIAO_PWM_CHAR_PROP (BLERead|BLEWrite)                           // property:PWM characteristic, readable/writable
 #define XIAO_PWM_CHAR_TYPE BLEUnsignedCharCharacteristic                // type:PWM characteristic, unsigned char
 #define XIAO_PWM_CHAR_LEN 1                                             // length:PWM characteristic, 1 byte
+#define XIAO_PWM_CHAR_NAME "pwm_duty"                                   // user descriptor: "pwm_duty"
 #define XIAO_VOLT_CHAR_UUID "AD0C2002-64E9-48B0-9088-6F9E9FE4972E"      // UUID:voltage characteristic 
 #define XIAO_VOLT_CHAR_PROP (BLERead|BLENotify)                         // property:voltage characteristic, readable/notifiable
 #define XIAO_VOLT_CHAR_TYPE BLECharacteristic                           // type:voltage characteristic, byte array
 #define XIAO_VOLT_CHAR_LEN 8                                            // length:voltage characteristic, 8 bytes
+#define XIAO_VOLT_CHAR_NAME "battery_data"                              // user descriptor: "battery_data"
 
 // BLE peripheral GATT profile: MaBeee side
 #define MABEEE_CTRL_SERV_UUID "B9F5FF00-D813-46C6-8B61-B453EE2C74D9"    // UUID:MaBeee control service

--- a/iot_train.ino
+++ b/iot_train.ino
@@ -43,6 +43,13 @@ BLECharacteristic tempCharacteristic(XIAO_TEMP_CHAR_UUID, XIAO_TEMP_CHAR_PROP, X
 BLECharacteristic ledCharacteristic(XIAO_LED_CHAR_UUID, XIAO_LED_CHAR_PROP, XIAO_LED_CHAR_LEN);                 // GATT: LED characteristic
 BLECharacteristic pwmCharacteristic(XIAO_PWM_CHAR_UUID, XIAO_PWM_CHAR_PROP, XIAO_PWM_CHAR_LEN);                 // GATT: PWM characteristic
 BLECharacteristic voltCharacteristic(XIAO_VOLT_CHAR_UUID, XIAO_VOLT_CHAR_PROP, XIAO_VOLT_CHAR_LEN);             // GATT: voltage characteristic
+BLEDescriptor commandDescriptor("2901", XIAO_COMMAND_CHAR_NAME);
+BLEDescriptor accelDescriptor("2901", XIAO_ACCEL_CHAR_NAME);
+BLEDescriptor gyroDescriptor("2901", XIAO_GYRO_CHAR_NAME);
+BLEDescriptor tempDescriptor("2901", XIAO_TEMP_CHAR_NAME);
+BLEDescriptor ledDescriptor("2901", XIAO_LED_CHAR_NAME);
+BLEDescriptor pwmDescriptor("2901", XIAO_PWM_CHAR_NAME);
+BLEDescriptor voltDescriptor("2901", XIAO_VOLT_CHAR_NAME);
 
 // handler for writable characteristics
 void onCommandWritten(BLEDevice, BLECharacteristic);
@@ -125,6 +132,13 @@ void setup() {
     commandCharacteristic.setEventHandler(BLEWritten, onCommandWritten);
     ledCharacteristic.setEventHandler(BLEWritten, onLedWritten);
     pwmCharacteristic.setEventHandler(BLEWritten, onPwmWritten);
+    commandCharacteristic.addDescriptor(commandDescriptor);
+    accelCharacteristic.addDescriptor(accelDescriptor);
+    gyroCharacteristic.addDescriptor(gyroDescriptor);
+    tempCharacteristic.addDescriptor(tempDescriptor);
+    ledCharacteristic.addDescriptor(ledDescriptor);
+    pwmCharacteristic.addDescriptor(pwmDescriptor);
+    voltCharacteristic.addDescriptor(voltDescriptor);
     xiaoService.addCharacteristic(commandCharacteristic);
     xiaoService.addCharacteristic(accelCharacteristic);
     xiaoService.addCharacteristic(gyroCharacteristic);


### PR DESCRIPTION
7つの XIAO characteristic に user descriptor を付けました。競技システムには特に影響ありませんが、BLEスキャナでは characteristic に名前が付いて理解しやすくなります。名前や変数名は適宜変えてもらって構いません。